### PR TITLE
Fix libmemcached un-tar and directory path

### DIFF
--- a/src/cookbook/initializing.md
+++ b/src/cookbook/initializing.md
@@ -78,11 +78,12 @@ location:
 You will need Nanomsg and Libmemcached to compile Openchange.
 
     $ wget http://download.nanomsg.org/nanomsg-0.5-beta.tar.gz https://launchpadlibrarian.net/165454254/libmemcached-1.0.18.tar.gz
-    $ tar -xvf nanomsg-0.5-beta.tar.gz libmemcached-1.0.18.tar.gz
+    $ tar -xvf nanomsg-0.5-beta.tar.gz
+    $ tar -xvf libmemcached-1.0.18.tar.gz
     $ cd nanomsg-0.5-beta
     $ ./configure
     $ sudo make install
-    $ cd ../memcached-1.0.18
+    $ cd ../libmemcached-1.0.18
     $ ./configure
     $ sudo make install
     $ sudo ldconfig


### PR DESCRIPTION
At least on my machine, "tar (GNU tar) 1.27.1" (Ubuntu), specifying both names on the same line tries to extract the libmemcached tarball from the nanomsg tarball.
