### PR TITLE
Add step to return to the parent directory

### DIFF
--- a/src/cookbook/initializing.md
+++ b/src/cookbook/initializing.md
@@ -86,6 +86,7 @@ You will need Nanomsg and Libmemcached to compile Openchange.
     $ ./configure
     $ sudo make install
     $ sudo ldconfig
+    $ cd ..
 
 
 # Next: Download the Source #


### PR DESCRIPTION
The next step in the cookbook is to clone the openchange repo. We don't want to do that inside the (lib)memcached directory.
